### PR TITLE
Users can now specify CPU, memory, and swap limits for each workspace.

### DIFF
--- a/phoenix-app/config/dev.exs
+++ b/phoenix-app/config/dev.exs
@@ -2,15 +2,25 @@
 
 import Config
 
+db_url = System.get_env("DATABASE_URL")
+
 # Configure your database
 config :rawpair, RawPair.Repo,
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  database: "rawpair_dev",
-  stacktrace: true,
-  show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  (if db_url do
+    [url: db_url]
+  else
+    [
+      username: "postgres",
+      password: "postgres",
+      hostname: "localhost",
+      database: "rawpair_dev"
+    ]
+  end)
+  |> Keyword.merge([
+    stacktrace: true,
+    show_sensitive_data_on_connection_error: true,
+    pool_size: 10
+  ])
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/phoenix-app/lib/rawpair/docker/workspace_manager.ex
+++ b/phoenix-app/lib/rawpair/docker/workspace_manager.ex
@@ -9,6 +9,23 @@ defmodule RawPair.Docker.WorkspaceManager do
 
   @app_dir "/home/devuser/app"
 
+  @default_cpu "2.5"
+  @default_mem "2.5g"
+  @default_swap "4g"
+
+  def effective_cpu(%Workspace{cpu_limit: nil}), do: @default_cpu
+  def effective_cpu(%Workspace{cpu_limit: val}), do: val
+
+  def effective_mem(%Workspace{mem_limit: nil}), do: @default_mem
+  def effective_mem(%Workspace{mem_limit: val}), do: val
+
+  def effective_swap(%Workspace{mem_swap: nil}), do: @default_swap
+  def effective_swap(%Workspace{mem_swap: val}), do: val
+
+  def default_cpu, do: @default_cpu
+  def default_mem, do: @default_mem
+  def default_swap, do: @default_swap
+
 
   def start_workspace(%Workspace{} = workspace) do
     # generate container name
@@ -64,9 +81,9 @@ defmodule RawPair.Docker.WorkspaceManager do
       "--label", "rawpair.workspace_slug=#{workspace.slug}",
       "--mount", "source=#{volume_name},target=#{@app_dir}",
       "--network", @docker_network,
-      "--cpus=2.5",
-      "--memory=2.5g",
-      "--memory-swap=4g",
+      "--cpus=#{effective_cpu(workspace)}",
+      "--memory=#{effective_mem(workspace)}",
+      "--memory-swap=#{effective_swap(workspace)}",
     ] ++ device_flags ++ [image]
 
     :ok = remove_existing_container(container_name)

--- a/phoenix-app/lib/rawpair/workspaces/workspace.ex
+++ b/phoenix-app/lib/rawpair/workspaces/workspace.ex
@@ -15,6 +15,9 @@ defmodule RawPair.Workspaces.Workspace do
     field :workspace_port, :integer
     field :postgres_port, :integer
     field :devices, {:array, :string}, default: []
+    field :cpu_limit, :string
+    field :mem_limit, :string
+    field :mem_swap, :string
     field :status, Ecto.Enum, values: [:pending, :starting, :running, :stopped, :failed], default: :pending
     field :last_active_at, :utc_datetime
 
@@ -33,12 +36,18 @@ defmodule RawPair.Workspaces.Workspace do
       :postgres_port,
       :status,
       :last_active_at,
-      :devices
+      :devices,
+      :cpu_limit,
+      :mem_limit,
+      :mem_swap
     ])
     |> maybe_generate_slug()
     |> validate_required([:name, :docker_image])
     |> unique_constraint(:slug)
     |> validate_devices()
+    |> validate_format(:cpu_limit, ~r/^\d+(\.\d+)?$/, message: "Invalid CPU format")
+    |> validate_format(:mem_limit, ~r/^\d+(\.\d+)?[gm]$/i, message: "Invalid memory format")
+    |> validate_format(:mem_swap, ~r/^\d+(\.\d+)?[gm]$/i, message: "Invalid swap format")
   end
 
   defp maybe_generate_slug(changeset) do

--- a/phoenix-app/lib/rawpair_web/components/core_components.ex
+++ b/phoenix-app/lib/rawpair_web/components/core_components.ex
@@ -379,7 +379,7 @@ defmodule RawPairWeb.CoreComponents do
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "mt-2 block w-full rounded-lg border-1 focus:ring-0 sm:text-sm sm:leading-6",
+          "mt-2 block w-full rounded-lg border-1 focus:ring-0 sm:text-sm sm:leading-6 px-1",
           @errors == [] && "border-white",
           @errors != [] && "border-destructive "
         ]}

--- a/phoenix-app/lib/rawpair_web/live/workspace_live/form_component.ex
+++ b/phoenix-app/lib/rawpair_web/live/workspace_live/form_component.ex
@@ -87,6 +87,30 @@ defmodule RawPairWeb.WorkspaceLive.FormComponent do
         />
         <p class="text-sm text-gray-500 mt-1">These will be mounted into the container using <code>--device=</code>.</p>
 
+        <.input
+          field={@form[:cpu_limit]}
+          type="text"
+          label="CPU Limit"
+          placeholder={"e.g. #{@default_cpu}"}
+        />
+        <.input
+          field={@form[:mem_limit]}
+          type="text"
+          label="Memory Limit"
+          placeholder={"e.g. #{@default_mem}"}
+        />
+        <.input
+          field={@form[:mem_swap]}
+          type="text"
+          label="Memory + Swap Limit"
+          placeholder={"e.g. #{@default_swap}"}
+        />
+        <p class="text-sm text-gray-500 mt-1">
+          If unset, defaults are <code><%= @default_cpu %></code> CPUs,
+          <code><%= @default_mem %></code> memory,
+          <code><%= @default_swap %></code> total (memory+swap).
+        </p>
+
 
         <:actions>
           <.button phx-disable-with="Saving...">Save Workspace</.button>

--- a/phoenix-app/lib/rawpair_web/live/workspace_live/index.ex
+++ b/phoenix-app/lib/rawpair_web/live/workspace_live/index.ex
@@ -13,6 +13,9 @@ defmodule RawPairWeb.WorkspaceLive.Index do
     socket =
       socket
       |> assign(:username, username)
+      |> assign(:default_cpu, RawPair.Docker.WorkspaceManager.default_cpu())
+      |> assign(:default_mem, RawPair.Docker.WorkspaceManager.default_mem())
+      |> assign(:default_swap, RawPair.Docker.WorkspaceManager.default_swap())
       |> stream(:workspaces, Workspaces.list_workspaces())
 
     {:ok, socket}

--- a/phoenix-app/lib/rawpair_web/live/workspace_live/index.html.heex
+++ b/phoenix-app/lib/rawpair_web/live/workspace_live/index.html.heex
@@ -19,6 +19,9 @@
       <:col :let={{_id, workspace}} label="Slug">{workspace.slug}</:col>
       <:col :let={{_id, workspace}} label="Description">{workspace.description}</:col>
       <:col :let={{_id, workspace}} label="Docker image">{workspace.docker_image}</:col>
+      <:col :let={{_id, workspace}} label="CPU Limit">{workspace.cpu_limit}</:col>
+      <:col :let={{_id, workspace}} label="Memory Limit">{workspace.mem_limit}</:col>
+      <:col :let={{_id, workspace}} label="Memory Swap">{workspace.mem_swap}</:col>
       <:col :let={{_id, workspace}} label="With DB?">{workspace.with_db}</:col>
       <:col :let={{_id, workspace}} label="Devices">
         <%= Enum.join(workspace.devices || [], ", ") %>
@@ -80,6 +83,9 @@
     title={@page_title}
     action={@live_action}
     workspace={@workspace}
+    default_cpu={@default_cpu}
+    default_mem={@default_mem}
+    default_swap={@default_swap}
     patch={~p"/workspaces"}
   />
 </.modal>

--- a/phoenix-app/mix.exs
+++ b/phoenix-app/mix.exs
@@ -6,7 +6,7 @@ defmodule RawPair.MixProject do
   def project do
     [
       app: :rawpair,
-      version: "0.0.0-a001",
+      version: "0.0.0-a002",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/phoenix-app/priv/repo/migrations/20250418195802_add_resource_limits_to_workspaces.exs
+++ b/phoenix-app/priv/repo/migrations/20250418195802_add_resource_limits_to_workspaces.exs
@@ -1,0 +1,11 @@
+defmodule RawPair.Repo.Migrations.AddResourceLimitsToWorkspaces do
+  use Ecto.Migration
+
+  def change do
+    alter table(:workspaces) do
+      add :cpu_limit, :string
+      add :mem_limit, :string
+      add :mem_swap, :string
+    end
+  end
+end


### PR DESCRIPTION
If unset, defaults are used (2.5 CPUs, 2.5g memory, 4g memory+swap).

Also updates the workspace form and schema to support these fields, and ensures Docker CLI args are built accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for setting custom CPU, memory, and swap limits per workspace.
  - Workspace creation and editing forms now include fields for specifying resource limits, with helpful default values and descriptions.
  - Workspace listings now display CPU, memory, and swap limits for each workspace.

- **Style**
  - Improved input field appearance with additional horizontal padding.

- **Chores**
  - Enhanced database configuration to support environment-based URLs for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->