### PR TITLE
Making ensureDeps command runnable when asdf is not in PATH

### DIFF
--- a/cli/cmd/ensureDeps.go
+++ b/cli/cmd/ensureDeps.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	minErlangVersion = "27.0.0"
-	minElixirVersion = "1.18.0"
-	minAsdfVersion   = "0.16.0"
+	minErlangVersion         = "27.0.0"
+	minElixirVersion         = "1.18.0"
+	minAsdfVersion           = "0.16.0"
+	asdfVersionToBeInstalled = "0.16.7"
 )
 
 var nonInteractive bool
@@ -53,7 +54,13 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 
 		fmt.Println("Proceeding with asdf, Erlang, and Elixir detection...")
 
-		hasASDF := executils.CheckInstalled("asdf")
+		hasASDF, err := setup.IsASDFInstalled()
+
+		if err != nil {
+			fmt.Println("Error checking for asdf installation:", err)
+			return
+		}
+
 		hasErlang := executils.CheckInstalled("erl")
 		hasElixir := executils.CheckInstalled("elixir")
 
@@ -127,7 +134,7 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 
 				shellRcFile, shellRcFileErr := osutils.DetectShellRCFile()
 
-				pathToAsdf, err = setup.InstallASDF(shellRcFile)
+				pathToAsdf, err = setup.InstallASDF(shellRcFile, asdfVersionToBeInstalled)
 
 				if err != nil {
 					fmt.Println("asdf installation failed:", err)

--- a/cli/cmd/ensureDeps.go
+++ b/cli/cmd/ensureDeps.go
@@ -54,7 +54,7 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 
 		fmt.Println("Proceeding with asdf, Erlang, and Elixir detection...")
 
-		hasASDF, err := setup.IsASDFInstalled()
+		pathToAsdf, err := setup.GetPathToASDF()
 
 		if err != nil {
 			fmt.Println("Error checking for asdf installation:", err)
@@ -63,8 +63,7 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 
 		hasErlang := executils.CheckInstalled("erl")
 		hasElixir := executils.CheckInstalled("elixir")
-
-		var pathToAsdf string
+		hasASDF := pathToAsdf != ""
 
 		if hasErlang && hasElixir {
 			meetsDeps := true
@@ -144,12 +143,6 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 
 				if shellRcFileErr != nil {
 					fmt.Println("Could not detect shell RC file so asdf is not in PATH.")
-				}
-			} else {
-				pathToAsdf, err = executils.GetPathToExecutable("asdf")
-				if err != nil {
-					fmt.Println("asdf is not in PATH.")
-					return
 				}
 			}
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.0.0-a014",
+	Version: "0.0.0-a015",
 	Use:     "rawpair",
 	Short:   "CLI tool for RawPair development environments",
 	Long: `RawPair CLI provides utilities to help set up and manage

--- a/cli/internal/setup/setup.go
+++ b/cli/internal/setup/setup.go
@@ -10,35 +10,35 @@ import (
 	"github.com/rawpair/rawpair/cli/internal/executils"
 )
 
-func IsASDFInstalled() (bool, error) {
-	hasASDF := executils.CheckInstalled("asdf")
+func GetPathToASDF() (string, error) {
+	asdfPath, _ := exec.LookPath("asdf")
 
-	if hasASDF {
-		return true, nil
+	if asdfPath != "" {
+		return asdfPath, nil
 	}
 
 	home, err := os.UserHomeDir()
 
 	if err != nil {
-		return false, fmt.Errorf("could not get home directory: %w", err)
+		return "", fmt.Errorf("could not get home directory: %w", err)
 	}
 
-	asdfPath := filepath.Join(home, ".asdf", "bin", "asdf")
+	asdfPath = filepath.Join(home, ".asdf", "bin", "asdf")
 
 	info, err := os.Stat(asdfPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil // File doesn't exist
+			return "", nil // File doesn't exist
 		}
-		return false, fmt.Errorf("could not stat %q: %w", asdfPath, err)
+		return "", fmt.Errorf("could not stat %q: %w", asdfPath, err)
 	}
 
 	// Check if it's a regular file and executable by user/group/others
 	if info.Mode().IsRegular() && info.Mode().Perm()&0111 != 0 {
-		return true, nil
+		return asdfPath, nil
 	}
 
-	return false, nil
+	return "", nil
 }
 
 func InstallASDF(shellRcFile string, asdfVersionToBeInstalled string) (string, error) {

--- a/cli/internal/setup/setup.go
+++ b/cli/internal/setup/setup.go
@@ -10,19 +10,45 @@ import (
 	"github.com/rawpair/rawpair/cli/internal/executils"
 )
 
-func InstallASDF(shellRcFile string) (string, error) {
+func IsASDFInstalled() (bool, error) {
+	hasASDF := executils.CheckInstalled("asdf")
+
+	if hasASDF {
+		return true, nil
+	}
+
+	home, err := os.UserHomeDir()
+
+	if err != nil {
+		return false, fmt.Errorf("could not get home directory: %w", err)
+	}
+
+	asdfPath := filepath.Join(home, ".asdf", "bin", "asdf")
+
+	info, err := os.Stat(asdfPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // File doesn't exist
+		}
+		return false, fmt.Errorf("could not stat %q: %w", asdfPath, err)
+	}
+
+	// Check if it's a regular file and executable by user/group/others
+	if info.Mode().IsRegular() && info.Mode().Perm()&0111 != 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func InstallASDF(shellRcFile string, asdfVersionToBeInstalled string) (string, error) {
 	home, err := os.UserHomeDir()
 
 	if err != nil {
 		return "", fmt.Errorf("could not get home directory: %w", err)
 	}
 
-	asdfDir := filepath.Join(home, ".asdf")
-	if _, err := os.Stat(asdfDir); err == nil {
-		return "", fmt.Errorf("asdf possibly already installed at %s", asdfDir)
-	}
-
-	version := "v0.16.7"
+	version := fmt.Sprintf("v%s", asdfVersionToBeInstalled)
 	tarURL := fmt.Sprintf("https://github.com/asdf-vm/asdf/releases/download/%s/asdf-%s-%s-%s.tar.gz", version, version, runtime.GOOS, runtime.GOARCH)
 	tarPath := "/tmp/asdf.tar.gz"
 
@@ -33,7 +59,7 @@ func InstallASDF(shellRcFile string) (string, error) {
 	}
 
 	// Create .asdf/bin directory
-	binDir := filepath.Join(asdfDir, "bin")
+	binDir := filepath.Join(home, ".asdf", "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		return "", fmt.Errorf("failed to create bin directory: %w", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit version control for the installation of the asdf tool, ensuring a specific version is installed.
- **Bug Fixes**
  - Improved error handling and detection when checking for the presence of the asdf tool.
- **Chores**
  - Updated CLI tool version to 0.0.0-a015.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->