### PR TITLE
Add flag to attempt installation of dependencies

### DIFF
--- a/cli/cmd/ensureDeps.go
+++ b/cli/cmd/ensureDeps.go
@@ -21,6 +21,7 @@ const (
 	asdfVersionToBeInstalled = "0.16.7"
 )
 
+var installDeps bool
 var nonInteractive bool
 
 var depCommands = map[string][]string{
@@ -109,16 +110,30 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 				return
 			}
 
-			fmt.Println("Ensure the following dependencies are satisfied/installed:")
-			for _, c := range cmds {
-				fmt.Println("  ", c)
-			}
+			if installDeps {
+				fmt.Println("Attempting to install dependencies...")
+				for _, c := range cmds {
+					fmt.Println("Running:", c)
+					err := executils.RunCommandString(c)
+					if err != nil {
+						fmt.Println("Error running command:", c, err)
+						return
+					}
+					fmt.Println("Command completed successfully.")
+				}
+				fmt.Println("Dependencies installed successfully.")
+			} else {
+				fmt.Println("Ensure the following dependencies are satisfied/installed:")
+				for _, c := range cmds {
+					fmt.Println("  ", c)
+				}
 
-			proceed := userflow.AskToProceedOrAuto("Proceed with asdf detection?", nonInteractive)
+				proceed := userflow.AskToProceedOrAuto("Proceed with asdf detection?", nonInteractive)
 
-			if !proceed {
-				fmt.Println("Aborted.")
-				return
+				if !proceed {
+					fmt.Println("Aborted.")
+					return
+				}
 			}
 
 			if !hasASDF {
@@ -203,5 +218,6 @@ Supports most common Linux distributions: Ubuntu, Debian, Fedora, Arch.
 func init() {
 	rootCmd.AddCommand(ensureDepsCmd)
 
+	ensureDepsCmd.Flags().BoolVar(&installDeps, "install-deps", false, "Attempts to install dependencies automatically")
 	ensureDepsCmd.Flags().BoolVar(&nonInteractive, "non-interactive", false, "Run without prompting for confirmation")
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.0.0-a015",
+	Version: "0.0.0-a016",
 	Use:     "rawpair",
 	Short:   "CLI tool for RawPair development environments",
 	Long: `RawPair CLI provides utilities to help set up and manage

--- a/cli/internal/executils/executils.go
+++ b/cli/internal/executils/executils.go
@@ -1,6 +1,11 @@
 package executils
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
 
 func CheckInstalled(name string) bool {
 	_, err := exec.LookPath(name)
@@ -18,4 +23,17 @@ func RunCommandAndReturnOutput(cmd string, args ...string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+func RunCommandString(cmdStr string) error {
+	args := strings.Fields(cmdStr)
+	if len(args) == 0 {
+		return fmt.Errorf("empty command string")
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI flag `--install-deps` to automatically install required system dependencies for building Erlang and Elixir, with real-time command execution and feedback.
- **Enhancements**
  - Improved user experience by displaying executed commands and their outcomes during the dependency installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->