### PR TITLE
Add arm64 Support to detect_local_platform Function

### DIFF
--- a/phoenix-app/lib/rawpair/application.ex
+++ b/phoenix-app/lib/rawpair/application.ex
@@ -65,8 +65,8 @@ defmodule RawPair.Application do
     |> case do
       "x86_64" -> "linux/amd64"
       "aarch64" -> "linux/arm64"
+      "arm64" -> "linux/arm64"
       other -> raise "Unsupported local platform: #{other}"
     end
   end
-
 end


### PR DESCRIPTION
### Description

This pull request fixes the architecture detection logic in the `detect_local_platform` function by adding support for the `arm64` architecture.

### Changes Made

- Updated the `detect_local_platform` function to handle the `arm64` case:
  ```elixir
  defp detect_local_platform do
    {arch, 0} = System.cmd("uname", ["-m"])

    arch
    |> String.trim()
    |> case do
      "x86_64" -> "linux/amd64"
      "aarch64" -> "linux/arm64"
      "arm64" -> "linux/arm64" # Added support for arm64
      other -> raise "Unsupported local platform: #{other}"
    end
  end
  ```

### Related Issue

Closes [#48](https://github.com/rawpair/rawpair/issues/48)