### PR TITLE
Parametrize VERSION in Makefile for .deb generation

### DIFF
--- a/.github/workflows/build-and-release-deb.yml
+++ b/.github/workflows/build-and-release-deb.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo apt-get install -y ruby ruby-dev build-essential libssl-dev && sudo gem install --no-document fpm
 
       - name: Build RawPair .deb for amd64
-        run: make ARCH=amd64
+        run: make ARCH=amd64 RAW_VERSION=${{ github.ref_name }}
 
       - name: Upload .deb to GitHub Release
         uses: softprops/action-gh-release@v2
@@ -50,7 +50,7 @@ jobs:
         run: sudo apt-get install -y ruby ruby-dev build-essential libssl-dev && sudo gem install --no-document fpm
 
       - name: Build RawPair .deb for arm64
-        run: make ARCH=arm64
+        run: make ARCH=arm64 RAW_VERSION=${{ github.ref_name }}
 
       - name: Upload .deb to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ stage:
 	mkdir -p $(STAGING_DIR)/etc/logrotate.d
 
 	cp -r $(BUILD_DIR)/* $(STAGING_DIR)/opt/$(APP_NAME)/
+	cp packaging/run-migrations.sh $(STAGING_DIR)/opt/$(APP_NAME)/bin
 	cp packaging/rawpair.env.default $(STAGING_DIR)/etc/$(APP_NAME)/rawpair.env.default
 	cp packaging/rawpair.service $(STAGING_DIR)/lib/systemd/system/rawpair.service
 	cp packaging/rawpair.logrotate $(STAGING_DIR)/etc/logrotate.d/$(APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 APP_NAME=rawpair
-VERSION=0.0.0~a025
+VERSION?=$(shell echo $(RAW_VERSION) | sed 's/^v//')
 ARCH?=amd64
 BUILD_DIR=phoenix-app/_build/prod/rel/$(APP_NAME)
 STAGING_DIR=dist/deb/$(APP_NAME)

--- a/packaging/run-migrations.sh
+++ b/packaging/run-migrations.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+[ -z "$DATABASE_URL" ] && { echo "Missing DATABASE_URL"; exit 1; }
+
+exec /opt/rawpair/bin/rawpair eval "Rawpair.Release.migrate"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build process to automatically set the package version based on the current GitHub tag, ensuring version numbers in release packages match the release tag.
  - Added a database migration script to support seamless updates during deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->