### PR TITLE
CLI tool in .deb package

### DIFF
--- a/.github/workflows/build-and-release-deb.yml
+++ b/.github/workflows/build-and-release-deb.yml
@@ -19,6 +19,16 @@ jobs:
           elixir-version: '1.18.3'
           otp-version: '27.3.2'
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Build RawPair CLI
+        run: |
+          cd cli
+          go build -o ../rawpair-cli
+
       - name: Install packaging dependencies
         run: sudo apt-get install -y ruby ruby-dev build-essential libssl-dev && sudo gem install --no-document fpm
 
@@ -47,6 +57,16 @@ jobs:
         with:
           elixir-version: '1.18.3'
           otp-version: '27.3.2'
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Build RawPair CLI
+        run: |
+          cd cli
+          go build -o ../rawpair-cli
 
       - name: Install packaging dependencies
         run: sudo apt-get install -y ruby ruby-dev build-essential libssl-dev && sudo gem install --no-document fpm

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docker-compose.yml
 .env
 dist
 *.deb
+rawpair-cli

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ ARCH?=amd64
 BUILD_DIR=phoenix-app/_build/prod/rel/$(APP_NAME)
 STAGING_DIR=dist/deb/$(APP_NAME)
 DEB_NAME=$(APP_NAME)_$(VERSION)_$(ARCH).deb
+CLI_BUILD_DIR=cli
 
 .PHONY: all build-release stage deb clean
 
-all: build-release stage deb
+all: build-release build-cli stage deb
+
+build-cli:
+	cd $(CLI_BUILD_DIR) && go build -o ../rawpair-cli
 
 build-release:
 	cd phoenix-app && ./deploy.sh
@@ -22,7 +26,11 @@ stage:
 	mkdir -p $(STAGING_DIR)/etc/logrotate.d
 
 	cp -r $(BUILD_DIR)/* $(STAGING_DIR)/opt/$(APP_NAME)/
-	cp rawpair-cli $(STAGING_DIR)/opt/$(APP_NAME_CLI)/bin
+	if [ ! -f "rawpair-cli" ]; then \
+		echo "Error: rawpair-cli binary not found"; \
+		exit 1; \
+	fi
+	cp rawpair-cli $(STAGING_DIR)/opt/$(APP_NAME_CLI)/bin/
 	cp packaging/run-migrations.sh $(STAGING_DIR)/opt/$(APP_NAME)/bin
 	cp packaging/rawpair.env.default $(STAGING_DIR)/etc/$(APP_NAME)/rawpair.env.default
 	cp packaging/rawpair.service $(STAGING_DIR)/lib/systemd/system/rawpair.service

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 APP_NAME=rawpair
+APP_NAME_CLI=rawpair-cli
 VERSION?=$(shell echo $(RAW_VERSION) | sed 's/^v//')
 ARCH?=amd64
 BUILD_DIR=phoenix-app/_build/prod/rel/$(APP_NAME)
@@ -15,11 +16,13 @@ build-release:
 stage:
 	rm -rf $(STAGING_DIR)
 	mkdir -p $(STAGING_DIR)/opt/$(APP_NAME)
+	mkdir -p $(STAGING_DIR)/opt/$(APP_NAME_CLI)/bin
 	mkdir -p $(STAGING_DIR)/etc/$(APP_NAME)
 	mkdir -p $(STAGING_DIR)/lib/systemd/system
 	mkdir -p $(STAGING_DIR)/etc/logrotate.d
 
 	cp -r $(BUILD_DIR)/* $(STAGING_DIR)/opt/$(APP_NAME)/
+	cp rawpair-cli $(STAGING_DIR)/opt/$(APP_NAME_CLI)/bin
 	cp packaging/run-migrations.sh $(STAGING_DIR)/opt/$(APP_NAME)/bin
 	cp packaging/rawpair.env.default $(STAGING_DIR)/etc/$(APP_NAME)/rawpair.env.default
 	cp packaging/rawpair.service $(STAGING_DIR)/lib/systemd/system/rawpair.service

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -10,7 +10,7 @@ import (
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.0.0-a025",
+	Version: "0.0.1",
 	Use:     "rawpair",
 	Short:   "CLI tool for RawPair development environments",
 	Long: `RawPair CLI provides utilities to help set up and manage

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -50,6 +50,7 @@ fi
 
 mkdir -p /opt/rawpair/tmp
 chown -R "$RAWPAIR_USER:$RAWPAIR_GROUP" /opt/rawpair/tmp
+ln -s /opt/rawpair-cli/bin/rawpair-cli /usr/local/bin/rawpair-cli
 
 if getent group docker >/dev/null; then
   usermod -aG docker "$RAWPAIR_USER"

--- a/packaging/postinst.sh
+++ b/packaging/postinst.sh
@@ -50,7 +50,17 @@ fi
 
 mkdir -p /opt/rawpair/tmp
 chown -R "$RAWPAIR_USER:$RAWPAIR_GROUP" /opt/rawpair/tmp
-ln -s /opt/rawpair-cli/bin/rawpair-cli /usr/local/bin/rawpair-cli
+# Ensure CLI is accessible in PATH
+if [ -f "/opt/rawpair-cli/bin/rawpair-cli" ]; then
+  # Remove existing symlink if it exists
+  if [ -L "/usr/local/bin/rawpair-cli" ]; then
+    rm -f /usr/local/bin/rawpair-cli
+  fi
+  ln -sf /opt/rawpair-cli/bin/rawpair-cli /usr/local/bin/rawpair-cli
+  echo "Symlink created for rawpair-cli in /usr/local/bin"
+else
+  echo "Warning: rawpair-cli binary not found in /opt/rawpair-cli/bin"
+fi
 
 if getent group docker >/dev/null; then
   usermod -aG docker "$RAWPAIR_USER"

--- a/packaging/postrm.sh
+++ b/packaging/postrm.sh
@@ -15,7 +15,10 @@ if [ -f "/lib/systemd/system/$SERVICE_NAME" ]; then
   systemctl daemon-reload
 fi
 
+echo "Removing /opt/rawpair/tmp directory..." 
 rm -fr /opt/rawpair/tmp
+echo "Removing rawpair-cli symlink..." 
+rm -f /usr/local/bin/rawpair-cli
 
 if [ "$1" = "purge" ]; then
   echo "--- Starting purge actions ---"

--- a/packaging/rawpair.logrotate
+++ b/packaging/rawpair.logrotate
@@ -1,9 +1,10 @@
-/var/log/rawpair/*.log {
+/opt/rawpair/tmp/log/*.log {
     daily
     missingok
-    rotate 14
+    rotate 7
     compress
     delaycompress
     notifempty
     copytruncate
+    create 640 rawpair rawpair
 }

--- a/phoenix-app/mix.exs
+++ b/phoenix-app/mix.exs
@@ -6,7 +6,7 @@ defmodule RawPair.MixProject do
   def project do
     [
       app: :rawpair,
-      version: "0.0.0-a025",
+      version: "0.0.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The RawPair CLI tool is now included in the package and made accessible system-wide via a symbolic link at /usr/local/bin/rawpair-cli.

- **Chores**
  - Updated the build and packaging process to include the RawPair CLI binary for both amd64 and arm64 architectures.
  - Added rawpair-cli to the list of ignored files in version control.
  - Updated project and CLI version to 0.0.1.

- **Bug Fixes**
  - Adjusted log rotation settings: log files are now stored in /opt/rawpair/tmp/log, with retention reduced to 7 files and improved permissions for new logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->