### PR TITLE
Allow Debian versioning with tildes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_NAME=rawpair
 APP_NAME_CLI=rawpair-cli
-VERSION?=$(shell echo $(RAW_VERSION) | sed 's/^v//')
+VERSION ?= $(shell echo $(RAW_VERSION) | sed 's/^v//' | sed 's/-/~/')
 ARCH?=amd64
 BUILD_DIR=phoenix-app/_build/prod/rel/$(APP_NAME)
 STAGING_DIR=dist/deb/$(APP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP_NAME=rawpair
 APP_NAME_CLI=rawpair-cli
-VERSION ?= $(shell echo $(RAW_VERSION) | sed 's/^v//' | sed 's/-/~/')
+VERSION?=$(subst -,~, $(subst v,,$(RAW_VERSION)))
 ARCH?=amd64
 BUILD_DIR=phoenix-app/_build/prod/rel/$(APP_NAME)
 STAGING_DIR=dist/deb/$(APP_NAME)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated version string formatting in the build process to remove all occurrences of "v" and replace hyphens with tildes, refining version normalization in build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->